### PR TITLE
add accept code of coduct role

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,14 @@ To start the timelord bot locally you will need to set the following env variabl
 
 - TOKEN='' *Discords bot token*
 - NEWS_CHANNEL='' *Channel number for whichever room you want a news feed in.*
-- COC_CHANNEL_ID='' *Channel where new users should be directed.*
+- COC_CHANNEL_ID='' *Channel where new members should be directed. Optional*
+- COC_ROLE_ID='' *This is the role that will be applied when a member agrees to your code of conduct. Optional*
+- ADMIN_CHANNEL_ID='' *The room where you would like notifications on when a member has agreed to the Code of Conduct. Optional*
 
 You will need to install dependentcies `yarn install`
 
 Add envs to a .env file and run `source .env`
 
 To run: `yarn start`
+To lint: `yarn lint`
 

--- a/README.md
+++ b/README.md
@@ -13,5 +13,3 @@ You will need to install dependentcies `yarn install`
 Add envs to a .env file and run `source .env`
 
 To run: `yarn start`
-To lint: `yarn lint`
-

--- a/index.js
+++ b/index.js
@@ -92,6 +92,31 @@ bot.registerCommand(
     }
 );
 
+bot.registerCommand(
+  'acceptcoc',
+  (msg) => {
+    const userID = msg.member.id;
+    const messageMods = `<@${userID}> has accepted the Code of Conduct.`;
+    const messageMember = 'Thanks for accepting the Code of Conduct, a mod will get you access to the wider server soon!';
+    const adminChannel = process.env.ADMIN_CHANNEL_ID;
+    const guildID = msg.channel.guild.id;
+    const reason = 'member accepts the Code of Conduct';
+    const cocRole = process.env.COC_ROLE_ID;
+
+    if (adminChannel) {
+      createMessage(adminChannel, messageMods);
+    }
+    if (cocRole) {
+      bot.addGuildMemberRole(guildID, userID, cocRole, reason);
+    }
+    createMessage(msg.channel.id, messageMember);
+  },
+  {
+    description: 'Accepts our discords Code of Conduct',
+    fullDescription: 'Pings mods and applies the COC role if configured.',
+  },
+);
+
 bot.connect();
 
 // helper functions


### PR DESCRIPTION
Member can now use !acceptcoc command
- If the cocRoleID has been configured the role will be added
- If the Admin channel ID was configured there will be a post in the admin channel 
- The bot will respond back to the member with a message after they use the command.

New Environment variables:

COC_ROLE_ID
ADMIN_CHANNEL_ID