### PR TITLE
fixed acceptcoc command

### DIFF
--- a/index.js
+++ b/index.js
@@ -92,7 +92,7 @@ bot.registerCommand('acceptcoc', (msg) => {
   const user = `<@${msg.member.id}>`;
 
   if (adminChannel) {
-    bot.createMessage(adminChannel, { content: ftl('accept-coc-admin-message', { user }) });
+    bot.createMessage(adminChannel, { content: ftl('acceptcoc-admin-message', { user }) });
   }
   if (cocRole) {
     bot.addGuildMemberRole(guildID, userID, cocRole, reason);

--- a/index.js
+++ b/index.js
@@ -89,14 +89,15 @@ bot.registerCommand('acceptcoc', (msg) => {
   const userID = msg.member.id;
   const guildID = msg.channel.guild.id;
   const reason = 'member accepts the Code of Conduct';
+  const user = `<@${msg.member.id}>`;
 
   if (adminChannel) {
-    bot.createMessage(adminChannel, { content: ftl('accept-coc-admin-message', { userID }) });
+    bot.createMessage(adminChannel, { content: ftl('accept-coc-admin-message', { user }) });
   }
   if (cocRole) {
     bot.addGuildMemberRole(guildID, userID, cocRole, reason);
   }
-  bot.createMessage(msg.channel.id, { content: ftl('accept-coc-message-member') });
+  bot.createMessage(msg.channel.id, { content: ftl('acceptcoc-member-message') });
 });
 
 bot.connect();

--- a/strings.ftl
+++ b/strings.ftl
@@ -75,4 +75,4 @@ acceptcoc-cmd-full-description = Pings mods and applies the COC role if configur
 acceptcoc-member-message = Thanks for accepting the Code of Conduct, a mod will get you access to the wider server soon!
 
 # $userId - The id of the user that accepted the CoC
-accept-coc-admin-message = <@{ $userID }> has accepted the Code of Conduct.
+accept-coc-admin-message = { $user } has accepted the Code of Conduct.

--- a/strings.ftl
+++ b/strings.ftl
@@ -74,5 +74,5 @@ acceptcoc-cmd-description = Accepts our discords Code of Conduct
 acceptcoc-cmd-full-description = Pings mods and applies the COC role if configured.
 acceptcoc-member-message = Thanks for accepting the Code of Conduct, a mod will get you access to the wider server soon!
 
-# $userId - The id of the user that accepted the CoC
-accept-coc-admin-message = { $user } has accepted the Code of Conduct.
+# $user - The discord formated id of the user that accepted the CoC
+acceptcoc-admin-message = { $user } has accepted the Code of Conduct.


### PR DESCRIPTION
Found two small issue that look like they came from the conversion to fluent.

1. typo causing a response string to be missing for acceptcoc-member-message
2. the userID used in the ftl file returns `<@&⁨211308040484290562⁩> has accepted the Code of Conduct.` in discord rather then a actual link to the user `@Errolyn⁩ has accepted the Code of Conduct.` in chat. After fiddling the only way I could make it work was for the whole userId string to be generated in the .js file and pass it as a whole. I'm not sure why that would be happening.

We are only using the name of the person elsewhere so it shouldn't be an issue.
