### PR TITLE
fixes dice rolls with negative modifiers

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,7 +1,7 @@
 {
   "extends": ["eslint:recommended", "prettier"],
   "plugins": ["prettier"],
-  "parserOptions": { "ecmaVersion": 10 },
+  "parserOptions": { "ecmaVersion": 11 },
   "env": {
     "node": true,
     "es6": true

--- a/commands/diceRoller.js
+++ b/commands/diceRoller.js
@@ -124,7 +124,7 @@ function parseDiceCommand(command) {
   let dice = new Object();
   const commandCleaned = command.toLowerCase().split(' ').join('').split('r').join(''); // removes spaces and Rs
   let [amount, diceConfig] = commandCleaned.split('d');
-  let [sides, modifier] = diceConfig.includes('+') ? diceConfig.split('+') : diceConfig.split('-');
+  let [sides, modifier] = diceConfig.split(/[+-]/);
   dice.reroll = command.toLowerCase().includes('r'); //Boolean
   dice.add = diceConfig.includes('+'); //Boolean
   dice.subtract = diceConfig.includes('-'); //Boolean

--- a/commands/diceRoller.js
+++ b/commands/diceRoller.js
@@ -124,13 +124,14 @@ function parseDiceCommand(command) {
   let dice = new Object();
   const commandCleaned = command.toLowerCase().split(' ').join('').split('r').join(''); // removes spaces and Rs
   let [amount, diceConfig] = commandCleaned.split('d');
-  let [sides, modifier] = diceConfig.split('+') || diceConfig.split('-');
+  let [sides, modifier] = diceConfig.includes('+') ? diceConfig.split('+') : diceConfig.split('-');
   dice.reroll = command.toLowerCase().includes('r'); //Boolean
   dice.add = diceConfig.includes('+'); //Boolean
   dice.subtract = diceConfig.includes('-'); //Boolean
   dice.amount = Number(amount); //Number
   dice.sides = Number(sides); //Number
-  dice.modifier = Number(modifier) || 0; // Sets the value of the modifier to 0 if not provided.
+  // I really don't like using the nullish operator inside of the Number method but this is the quickest fix for the time being, it seems weird to set 0 to a number when it already is one.
+  dice.modifier = Number(modifier ?? 0); // Sets the value of the modifier to 0 if not provided.
   if (validateRollParams(dice)) {
     return dice;
   }


### PR DESCRIPTION
Found a bug with negative modifiers in the diceRoller dice object builder logic. I also had to bump the "ecmaVersion" to enable the nullish operator for the project.