### PR TITLE
Add !vc command to manage temporary voice channels

### DIFF
--- a/commands/voiceChannelManager.js
+++ b/commands/voiceChannelManager.js
@@ -1,0 +1,251 @@
+let ftl = require('../lib/ftl');
+
+// Cleanup intervals under 5 minutes will not be reliable.
+const CLEANUP_INTERVAL_MINUTES = 5;
+const CHANNEL_TYPE = { TEXT: 0, VOICE: 2, GROUP: 4 };
+const EMOJIS = {
+  CHANNEL_PREFIX: '⚡',
+  SUCCESS: '✅',
+  CONFIRM_DELETE: '🔥',
+  CANCEL_DELETE: '🙊',
+  CLEANUP: '✂',
+};
+
+// string length is number of bytes, and many emoji are not one byte. Regex can handle that better.
+const oneChar = /^.$/u;
+for (const [name, emoji] of Object.entries(EMOJIS)) {
+  if (!emoji.match(oneChar)) {
+    throw new Error(`Emojis must be just one character, ${name} is too long`);
+  }
+}
+
+module.exports.register = ({ bot }) => {
+  new VcCommand({ bot });
+};
+
+class VcCommand {
+  constructor({ bot }) {
+    this.bot = bot;
+    this.trackedChannels = new Map();
+    this._targetGroup = null;
+
+    const vcCommand = bot.registerCommand('voice-channel', ftl('error-unknown-subcommand'), {
+      aliases: ['vc'],
+      argsRequired: true,
+      guildOnly: true,
+      ftlVariables: {
+        channelTimeoutMinutes: CLEANUP_INTERVAL_MINUTES * 2,
+        channelCleanupEmoji: EMOJIS.CLEANUP,
+      },
+    });
+
+    vcCommand.registerSubcommand('create', (...args) => this.subcommandCreate(...args), {
+      argsRequired: true,
+      guildOnly: true,
+    });
+
+    vcCommand.registerSubcommand('delete', (...args) => this.subcommandDelete(...args), {
+      argsRequired: true,
+      guildOnly: true,
+    });
+
+    vcCommand.registerSubcommand(
+      'delete-all',
+      (...args) => this.subcommandDeleteAllWarning(...args),
+      {
+        guildOnly: true,
+        reactionButtons: [
+          {
+            emoji: EMOJIS.CONFIRM_DELETE,
+            type: 'edit',
+            response: (...args) => this.reactionCommandDeleteAll(...args),
+          },
+          {
+            emoji: EMOJIS.CANCEL_DELETE,
+            type: 'cancel',
+            response: ftl('voice-channel-cmd-delete-all-canceled'),
+          },
+        ],
+      },
+    );
+
+    setInterval(() => this.cleanupTask(), CLEANUP_INTERVAL_MINUTES * 60 * 1000);
+    // Check for channel updates right away, with a short delay to allow the bot to log in.
+    setTimeout(() => this.cleanupTask(), 1000);
+  }
+
+  async getChannelGroup(guild) {
+    if (!this._targetGroup) {
+      const channels = await this.bot.getRESTGuildChannels(guild.id);
+      let targetGroup = channels.find((channel) => channel.name.startsWith(EMOJIS.CHANNEL_PREFIX));
+      if (!targetGroup) {
+        targetGroup = await this.bot.createChannel(
+          guild.id,
+          `${EMOJIS.CHANNEL_PREFIX} AUTO CHANNELS`,
+          CHANNEL_TYPE.GROUP,
+          {
+            reason: `To hold !vc command channesl`,
+          },
+        );
+      }
+      this._targetGroup = targetGroup;
+    }
+    return this._targetGroup;
+  }
+
+  async findChannel(guild, needle) {
+    needle = needle.toLowerCase();
+    const channels = await this.bot.getRESTGuildChannels(guild.id);
+    let matches = channels
+      .filter((channel) => channel.name.startsWith(EMOJIS.CHANNEL_PREFIX))
+      .filter((channel) => channel.name.toLowerCase().includes(needle));
+    if (matches.length) {
+      return matches[0];
+    }
+    return null;
+  }
+
+  async subcommandCreate(message, args) {
+    const guild = message.channel.guild;
+    const parentGroup = await this.getChannelGroup(guild);
+    const channelName = [EMOJIS.CHANNEL_PREFIX, ...args].join(' ');
+    if (channelName.length > 100) {
+      return ftl('voice-channel-cmd-error-channel-name-too-long');
+    }
+    await this.bot.createChannel(guild.id, channelName, CHANNEL_TYPE.VOICE, {
+      reason: `Created by ${message.author.username} with !vc create.`,
+      parentID: parentGroup.id,
+    });
+    await this.bot.addMessageReaction(
+      message.channel.id,
+      message.id,
+      encodeURIComponent(EMOJIS.SUCCESS),
+    );
+  }
+
+  subcommandDeleteAllWarning() {
+    return ftl('voice-channel-cmd-delete-all-warning', {
+      prefixEmoji: EMOJIS.CHANNEL_PREFIX,
+      confirmEmoji: EMOJIS.CONFIRM_DELETE,
+      cancelEmoji: EMOJIS.CANCEL_DELETE,
+    });
+  }
+
+  async reactionCommandDeleteAll(message) {
+    const guild = message.channel.guild;
+    const channels = await this.bot.getRESTGuildChannels(guild.id);
+    const deleteTasks = [];
+    const groups = [];
+
+    for (const channel of channels) {
+      // do channels later, for less UI flashing
+      if (channel.name.startsWith(EMOJIS.CHANNEL_PREFIX)) {
+        if (channel.type === CHANNEL_TYPE.GROUP) {
+          groups.push(channel);
+          continue;
+        }
+        deleteTasks.push(channel.delete(`!vc delete-all ran by ${message.author.username}`));
+      }
+    }
+
+    await Promise.all(deleteTasks);
+    await Promise.all(
+      groups.map((group) => group.delete(`!vc delete-all ran by ${message.author.username}`)),
+    );
+    return ftl('voice-channel-cmd-delete-all-completed');
+  }
+
+  async subcommandDelete(message, args) {
+    let channel = await this.findChannel(message.channel.guild, args.join(' '));
+    // channel is a REST channel, which doesn't have voice data. Upgrade it.
+    channel = await this.bot.getChannel(channel.id);
+
+    if (channel) {
+      if (channel.type === CHANNEL_TYPE.VOICE && channel.voiceMembers.size > 0) {
+        return ftl('voice-channel-cmd-error-channel-not-empty', { channelName: channel.name });
+      }
+
+      await channel.delete(`!vc delete ran by ${message.author.username}`);
+      await this.bot.addMessageReaction(
+        message.channel.id,
+        message.id,
+        encodeURIComponent(EMOJIS.SUCCESS),
+      );
+    } else {
+      return ftl('voice-channel-cmd-error-channel-not-found', {
+        prefixEmoji: EMOJIS.CHANNEL_PREFIX,
+      });
+    }
+  }
+
+  async getAllGuilds() {
+    const limit = 100;
+    const page = this.bot.getRESTGuilds(limit);
+    if (page.length >= limit) {
+      console.warning(
+        "Warning, a full page of guilds was returned, this probably means the voice channel manager won't work reliaby anymore",
+      );
+    }
+    return page;
+  }
+
+  async cleanupTask() {
+    for (const guild of await this.getAllGuilds()) {
+      let channels = await Promise.all(
+        (await this.bot.getRESTGuildChannels(guild.id))
+          // upgrade REST channels to non-Rest channels to get membership
+          .map((c) => this.bot.getChannel(c.id)),
+      );
+
+      // Channels we manage
+      const autoChannels = channels
+        .filter((c) => c.name.startsWith(EMOJIS.CHANNEL_PREFIX))
+        .filter((c) => c.type === CHANNEL_TYPE.VOICE);
+
+      // Channels that are in the process of expiring
+      let expiringChannels = autoChannels.filter((c) => c.name.includes(EMOJIS.CLEANUP));
+
+      // Any occupied channels should stop expiring
+      for (const channel of expiringChannels) {
+        if (channel.voiceMembers.size > 0) {
+          channel.name = channel.name.replace(EMOJIS.CLEANUP, '');
+          await channel.editChannel(channel.id, { name: channel.name });
+        }
+      }
+      expiringChannels = expiringChannels.filter((c) => c.name.includes(EMOJIS.CLEANUP));
+
+      // Channels with the cleanup emoji should be deleted
+      const expiredChannels = autoChannels.filter((c) =>
+        c.name.startsWith(EMOJIS.CHANNEL_PREFIX + EMOJIS.CLEANUP),
+      );
+      for (const channel of expiredChannels) {
+        await channel.delete('Auto channel expired');
+      }
+
+      // Check for any channels that need to start expiring
+      for (const channel of autoChannels) {
+        if (channel.name.includes(EMOJIS.CLEANUP)) {
+          // already handling this one
+          continue;
+        }
+        if (channel.voiceMembers.size === 0) {
+          const newName = channel.name.replace(
+            EMOJIS.CHANNEL_PREFIX,
+            EMOJIS.CHANNEL_PREFIX + EMOJIS.CLEANUP,
+          );
+          await channel.edit({ name: newName });
+        }
+      }
+
+      // Finally, if there are no more auto-channels, remove the group
+      channels = (await this.bot.getRESTGuildChannels(guild.id)).filter((c) =>
+        c.name.startsWith(EMOJIS.CHANNEL_PREFIX),
+      );
+      if (channels.every((c) => c.type === CHANNEL_TYPE.GROUP)) {
+        for (const channel of channels) {
+          await channel.delete('No auto channels remaining');
+        }
+      }
+    }
+  }
+}

--- a/commands/voiceChannelManager.js
+++ b/commands/voiceChannelManager.js
@@ -69,6 +69,11 @@ class VcCommand {
       },
     );
 
+    vcCommand.registerSubcommand('debug', (...args) => this.subcommandDebug(...args), {
+      guildOnly: true,
+      hidden: true,
+    });
+
     setInterval(() => this.cleanupTask(), CLEANUP_INTERVAL_MINUTES * 60 * 1000);
     // Check for channel updates right away, with a short delay to allow the bot to log in.
     setTimeout(() => this.cleanupTask(), 1000);
@@ -176,6 +181,40 @@ class VcCommand {
         prefixEmoji: EMOJIS.CHANNEL_PREFIX,
       });
     }
+  }
+
+  async subcommandDebug(message) {
+    let channels = await this.bot.getRESTGuildChannels(message.channel.guild.id);
+    let lines = ['Channels:'];
+    for (const channel of channels) {
+      let parts = [`* ${channel.name}`];
+
+      switch (channel.type) {
+        case CHANNEL_TYPE.VOICE:
+          parts.push('voice');
+          break;
+        case CHANNEL_TYPE.GROUP:
+          parts.push('group');
+          break;
+        case CHANNEL_TYPE.TEXT:
+          parts.push('text');
+          break;
+        default:
+          parts.push('unknown type');
+      }
+
+      if (channel.name.startsWith(EMOJIS.CHANNEL_PREFIX)) {
+        parts.push('managed');
+      }
+      if (channel.name.startsWith(EMOJIS.CHANNEL_PREFIX + EMOJIS.CLEANUP)) {
+        parts.push('expiring');
+      }
+      lines.push(parts.join(' - '));
+    }
+    let msg = lines.join('\n');
+    console.log('!vc debug');
+    console.log(msg);
+    return msg;
   }
 
   async getAllGuilds() {

--- a/commands/voiceChannelManager.js
+++ b/commands/voiceChannelManager.js
@@ -89,7 +89,7 @@ class VcCommand {
           `${EMOJIS.CHANNEL_PREFIX} AUTO CHANNELS`,
           CHANNEL_TYPE.GROUP,
           {
-            reason: `To hold !vc command channesl`,
+            reason: `To hold !vc command channels`,
           },
         );
       }
@@ -242,16 +242,20 @@ class VcCommand {
         .filter((c) => c.type === CHANNEL_TYPE.VOICE);
 
       // Channels that are in the process of expiring
-      let expiringChannels = autoChannels.filter((c) => c.name.includes(EMOJIS.CLEANUP));
+      let expiringChannels = autoChannels.filter((c) =>
+        c.name.startsWith(EMOJIS.CHANNEL_PREFIX + EMOJIS.CLEANUP),
+      );
 
       // Any occupied channels should stop expiring
       for (const channel of expiringChannels) {
         if (channel.voiceMembers.size > 0) {
           channel.name = channel.name.replace(EMOJIS.CLEANUP, '');
-          await channel.editChannel(channel.id, { name: channel.name });
+          await channel.edit(channel.id, { name: channel.name });
         }
       }
-      expiringChannels = expiringChannels.filter((c) => c.name.includes(EMOJIS.CLEANUP));
+      expiringChannels = expiringChannels.filter((c) =>
+        c.name.startsWith(EMOJIS.CHANNEL_PREFIX + EMOJIS.CLEANUP),
+      );
 
       // Channels with the cleanup emoji should be deleted
       const expiredChannels = autoChannels.filter((c) =>
@@ -263,7 +267,7 @@ class VcCommand {
 
       // Check for any channels that need to start expiring
       for (const channel of autoChannels) {
-        if (channel.name.includes(EMOJIS.CLEANUP)) {
+        if (channel.name.startsWith(EMOJIS.CHANNEL_PREFIX + EMOJIS.CLEANUP)) {
           // already handling this one
           continue;
         }

--- a/commands/voiceChannelManager.js
+++ b/commands/voiceChannelManager.js
@@ -27,7 +27,6 @@ class VcCommand {
   constructor({ bot }) {
     this.bot = bot;
     this.trackedChannels = new Map();
-    this._targetGroup = null;
 
     const vcCommand = bot.registerCommand('voice-channel', ftl('error-unknown-subcommand'), {
       aliases: ['vc'],
@@ -80,28 +79,26 @@ class VcCommand {
   }
 
   async getChannelGroup(guild) {
-    if (!this._targetGroup) {
-      const channels = await this.bot.getRESTGuildChannels(guild.id);
-      let targetGroup = channels.find((channel) => channel.name.startsWith(EMOJIS.CHANNEL_PREFIX));
-      if (!targetGroup) {
-        targetGroup = await this.bot.createChannel(
-          guild.id,
-          `${EMOJIS.CHANNEL_PREFIX} AUTO CHANNELS`,
-          CHANNEL_TYPE.GROUP,
-          {
-            reason: `To hold !vc command channels`,
-          },
-        );
-      }
-      this._targetGroup = targetGroup;
+    const channels = await this.bot.getRESTGuildChannels(guild.id);
+    let targetGroup = channels.find((channel) => channel.name.startsWith(EMOJIS.CHANNEL_PREFIX));
+    if (!targetGroup) {
+      targetGroup = await this.bot.createChannel(
+        guild.id,
+        `${EMOJIS.CHANNEL_PREFIX} AUTO CHANNELS`,
+        CHANNEL_TYPE.GROUP,
+        {
+          reason: `To hold !vc command channels`,
+        },
+      );
     }
-    return this._targetGroup;
+    return targetGroup;
   }
 
   async findChannel(guild, needle) {
     needle = needle.toLowerCase();
     const channels = await this.bot.getRESTGuildChannels(guild.id);
     let matches = channels
+      .filter((channel) => channel.type === CHANNEL_TYPE.VOICE)
       .filter((channel) => channel.name.startsWith(EMOJIS.CHANNEL_PREFIX))
       .filter((channel) => channel.name.toLowerCase().includes(needle));
     if (matches.length) {

--- a/index.js
+++ b/index.js
@@ -14,7 +14,9 @@ require('http')
 
 const bot = new BotWrapper(
   process.env.TOKEN,
-  {},
+  {
+    restMode: true,
+  },
   {
     owner: 'Errolyn',
     prefix: '!',
@@ -22,7 +24,7 @@ const bot = new BotWrapper(
 );
 
 bot.on('ready', () => {
-  console.log('Ready!');
+  console.log(`Ready at ${new Date().toLocaleString()}!`);
 });
 
 bot.on('error', (err) => {
@@ -36,5 +38,6 @@ bot.registerCommand('ping', () => {
 require('./commands/newsFeed').register({ bot });
 require('./commands/diceRoller').register({ bot });
 require('./commands/codeOfConduct').register({ bot });
+require('./commands/voiceChannelManager').register({ bot });
 
 bot.connect();

--- a/lib/BotWrapper.js
+++ b/lib/BotWrapper.js
@@ -17,6 +17,9 @@ module.exports = class BotWrapper extends eris.CommandClient {
     if (!options.fullDescription) {
       options.fullDescription = ftl(`${label}-cmd-full-description`, ftlVariables);
     }
+    if (!options.errorMessage) {
+      options.errorMessage = ftl(`error-unknown`);
+    }
 
     const command = super.registerCommand(label, generator, options);
     return commandWrapper(command);
@@ -34,6 +37,10 @@ function commandWrapper(command) {
           if (!options.fullDescription) {
             options.description = ftl(`${command.label}-${label}-cmd-full-description`);
           }
+          if (!options.errorMessage) {
+            options.errorMessage = ftl(`error-unknown`);
+          }
+
           return obj[prop](label, generator, options);
         };
       }

--- a/lib/BotWrapper.js
+++ b/lib/BotWrapper.js
@@ -10,13 +10,35 @@ module.exports = class BotWrapper extends eris.CommandClient {
     super(token, options, commandOptions);
   }
 
-  registerCommand(label, generator, options = {}) {
+  registerCommand(label, generator, { ftlVariables, ...options } = {}) {
     if (!options.description) {
-      options.description = ftl(`${label}-cmd-description`);
+      options.description = ftl(`${label}-cmd-description`, ftlVariables);
     }
     if (!options.fullDescription) {
-      options.fullDescription = ftl(`${label}-cmd-full-description`);
+      options.fullDescription = ftl(`${label}-cmd-full-description`, ftlVariables);
     }
-    return super.registerCommand(label, generator, options);
+
+    const command = super.registerCommand(label, generator, options);
+    return commandWrapper(command);
   }
 };
+
+function commandWrapper(command) {
+  return new Proxy(command, {
+    get(obj, prop) {
+      if (prop === 'registerSubcommand') {
+        return (label, generator, options = {}) => {
+          if (!options.description) {
+            options.description = ftl(`${command.label}-${label}-cmd-description`);
+          }
+          if (!options.fullDescription) {
+            options.description = ftl(`${command.label}-${label}-cmd-full-description`);
+          }
+          return obj[prop](label, generator, options);
+        };
+      }
+
+      return obj[prop];
+    },
+  });
+}

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -1,0 +1,3 @@
+module.exports = {
+  CHANNEL_TYPE: { TEXT: 0, VOICE: 2, GROUP: 4 },
+};

--- a/package.json
+++ b/package.json
@@ -14,23 +14,29 @@
     "start": "node -r dotenv/config index.js",
     "lint": "eslint . --ext .js",
     "format": "prettier ./.eslintrc.json -c **/*",
-    "test": "mocha tests/**.test.js"
+    "test": "mocha tests/**.test.js",
+    "coverage": "nyc npm run test"
   },
   "dependencies": {
     "@fluent/bundle": "^0.16.0",
     "dotenv": "^8.2.0",
     "eris": "^0.13.1",
-    "node-fetch": "^2.6.1"
+    "node-fetch": "^2.6.1",
+    "sinon": "^9.2.1",
+    "sinon-chai": "^3.5.0"
   },
   "devDependencies": {
     "chai": "^4.2.0",
     "eslint": "^7.7.0",
     "eslint-config-prettier": "^6.11.0",
     "eslint-plugin-prettier": "^3.1.4",
+    "faker": "^5.1.0",
     "husky": "^4.2.5",
     "lint-staged": "^10.2.11",
     "mocha": "^8.1.3",
-    "prettier": "^2.0.5"
+    "nyc": "^15.1.0",
+    "prettier": "^2.0.5",
+    "snowflake-util": "^1.0.1"
   },
   "husky": {
     "hooks": {

--- a/strings.ftl
+++ b/strings.ftl
@@ -2,7 +2,8 @@ bot-description = A helpful server bot
 
 ## General messages
 
-error-unknown-subcommand = Error: Unknown subcommand
+error-unknown-subcommand = Unknown subcommand
+error-unknown = Uh oh, something went wrong
 
 ## Ping Command
 
@@ -96,6 +97,8 @@ voice-channel-delete-all-cmd-description = Delete ALL channels and groups made b
 voice-channel-delete-all-cmd-full-description = { voice-channel-delete-all-cmd-description }
 voice-channel-delete-cmd-description = Delete one channel made by the !vc command.
 voice-channel-delete-cmd-full-description = { voice-channel-delete-cmd-description }
+voice-channel-debug-cmd-description = Debug the !vc command.
+voice-channel-debug-cmd-full-description = { voice-channel-debug-cmd-description }
 
 # $prefixEmoji
 # $confirmEmoji

--- a/strings.ftl
+++ b/strings.ftl
@@ -1,5 +1,9 @@
 bot-description = A helpful server bot
 
+## General messages
+
+error-unknown-subcommand = Error: Unknown subcommand
+
 ## Ping Command
 
 ping-cmd-description = Pong!
@@ -76,3 +80,37 @@ acceptcoc-member-message = Thanks for accepting the Code of Conduct, a mod will 
 
 # $user - The discord formated id of the user that accepted the CoC
 acceptcoc-admin-message = { $user } has accepted the Code of Conduct.
+
+
+## Voice Channel Manager command
+
+voice-channel-cmd-description = Manage temporary voice channels
+voice-channel-cmd-full-description =
+  { voice-channel-cmd-description }. Once empty, channels will last { $channelTimeoutMinutes } minutes before expiring. Channels marked with a { $channelCleanupEmoji } will be deleted soon if no-one joins them.
+
+  When specifying the names of existing channels for deletion or renaming, case doesn't matter and any unique substring can be used. For example, "Streaming Minecraft" could be matched by specifying only "minecraft" if no other channels contain the word minecraft.
+
+voice-channel-create-cmd-description = Make a new channel with the given name.
+voice-channel-create-cmd-full-description = { voice-channel-create-cmd-description }
+voice-channel-delete-all-cmd-description = Delete ALL channels and groups made by the !vc command.
+voice-channel-delete-all-cmd-full-description = { voice-channel-delete-all-cmd-description }
+voice-channel-delete-cmd-description = Delete one channel made by the !vc command.
+voice-channel-delete-cmd-full-description = { voice-channel-delete-cmd-description }
+
+# $prefixEmoji
+# $confirmEmoji
+# $cancelEmoji
+voice-channel-cmd-delete-all-warning =
+ Are you sure you want to delete ALL { $prefixEmoji } automatic voice channels?
+
+  { $confirmEmoji } - Yes, delete them all.
+  { $cancelEmoji } - No, I changed my mind.
+
+voice-channel-cmd-delete-all-canceled = Ok, I won't delete anything.
+voice-channel-cmd-delete-all-completed = All the automatic channels are gone now!
+
+voice-channel-cmd-error-channel-not-found = I couldn't find just one { $prefixEmoji } channel with that search term. Try again?
+
+# $channelName
+voice-channel-cmd-error-channel-not-empty = You can't delete { $channelName } because people are still using it.
+voice-channel-cmd-error-channel-name-too-long = That channel name is too long, sorry.

--- a/tests/diceRoller.test.js
+++ b/tests/diceRoller.test.js
@@ -1,5 +1,4 @@
 const expect = require('chai').expect;
-const assert = require('assert');
 const { rollDice, parseDiceCommand } = require('../commands/diceRoller').forTestsOnly;
 const { register } = require('../commands/diceRoller');
 const { MockBot } = require('./helpers/mockBot');
@@ -15,7 +14,7 @@ describe('diceRoller', function () {
     it('should never return a 1 if reroll is true', function () {
       for (let i = 0; i < 100; i++) {
         let results = rollDice({ amount: 1, sides: 4, reroll: true });
-        assert(results > 1);
+        expect(results).to.be.greaterThan(1);
       }
     });
 
@@ -28,7 +27,7 @@ describe('diceRoller', function () {
           }
         }
       }
-      assert(testResults() === 1);
+      expect(testResults()).to.equal(1);
     });
   });
   describe('#parseDiceCommand()', function () {
@@ -82,9 +81,11 @@ describe('diceRoller', function () {
   describe('#register()', function () {
     const bot = new MockBot();
     register({ bot });
-    it('should do something', function () {
-      const result = stripFltSpecialChars(bot.triggerCommand('roll', { content: '!roll 1d4+3' }));
-      assert(/A d4 \+ 3 was rolled to get [4-7]/.test(result));
+    it('should do something', async function () {
+      const result = stripFltSpecialChars(
+        await bot._triggerCommand('roll', { content: '!roll 1d4+3' }),
+      );
+      expect(result).to.match(/A d4 \+ 3 was rolled to get [4-7]/);
     });
   });
 });

--- a/tests/helpers/factories.js
+++ b/tests/helpers/factories.js
@@ -1,0 +1,47 @@
+const faker = require('faker');
+const Snowflake = require('snowflake-util');
+
+const { CHANNEL_TYPE } = require('../../lib/constants');
+
+const snowflake = new Snowflake();
+
+function messageFactory(args) {
+  return {
+    id: snowflake.generate(),
+    author: userFactory(),
+    channel: channelFactory(),
+    ...args,
+  };
+}
+
+function guildFactory(args) {
+  return {
+    id: snowflake.generate(),
+    ...args,
+  };
+}
+
+function channelFactory(args) {
+  return {
+    id: snowflake.generate(),
+    name: faker.lorem.slug(),
+    type: CHANNEL_TYPE.TEXT,
+    guild: guildFactory(),
+    voiceMembers: new Map(),
+    ...args,
+  };
+}
+
+function userFactory(args) {
+  return {
+    id: snowflake.generate(),
+    ...args,
+  };
+}
+
+module.exports = {
+  guildFactory,
+  messageFactory,
+  channelFactory,
+  userFactory,
+};

--- a/tests/helpers/mockBot.js
+++ b/tests/helpers/mockBot.js
@@ -1,15 +1,149 @@
+const { expect } = require('chai');
+const sinon = require('sinon');
+const { guildFactory, channelFactory, messageFactory } = require('./factories');
+
 class MockBot {
-  constructor() {
-    this.commands = {};
+  constructor({ channels = [{}] } = {}) {
+    this._commands = {};
+    this._guild = guildFactory();
+    this._auditLog = [];
+    this._channels = [];
+
+    for (const channel of channels) {
+      this._addChannel(channel);
+    }
+
+    let methodsToWrap = [
+      'createChannel',
+      'registerCommand',
+      'getRESTGuilds',
+      'getRESTGuildChannels',
+      'getChannel',
+      'deleteChannel',
+      'editChannel',
+    ];
+    for (const func of methodsToWrap) {
+      this[func] = sinon.fake(this[func]);
+    }
+
+    let methodsToMock = ['addMessageReaction'];
+    for (const func of methodsToMock) {
+      this[func] = sinon.mock();
+    }
   }
 
-  registerCommand(commandString, callback) {
-    this.commands[commandString] = callback;
+  async _triggerCommand(commandString, msg, args) {
+    return await this._commands[commandString].trigger(msg, args);
   }
 
-  triggerCommand(commandString, msg) {
-    return this.commands[commandString](msg);
+  _makeMessage(content = 'I like frogs', extras = {}) {
+    return messageFactory({
+      content,
+      guild: this._guild,
+      channel: channelFactory({ guild: this._guild }),
+      ...extras,
+    });
+  }
+
+  async _triggerMessage(content, extras) {
+    const message = this._makeMessage(content, extras);
+    let args;
+    let result;
+    if (content.startsWith('!')) {
+      let [commandString, ...args] = content.split(/\s+/);
+      commandString = commandString.slice(1);
+      if (this._commands[commandString]) {
+        result = await this._commands[commandString].trigger(message, args);
+      }
+    }
+
+    return { result, message, args };
+  }
+
+  _addChannel(channel) {
+    if (channel.guild && channel.guild != this._guild) {
+      throw new Error("Can't have more than one guild on mockbot");
+    }
+    const builtChannel = channelFactory({ ...channel, guild: this._guild });
+    expect(builtChannel).to.have.property('id');
+
+    builtChannel.delete = () => this.deleteChannel(builtChannel.id);
+    builtChannel.edit = (newName) => this.editChannel(builtChannel.id, newName);
+
+    this._channels.push(builtChannel);
+    return builtChannel;
+  }
+
+  registerCommand(commandString, callback, options = {}) {
+    let command = new MockCommand(callback, options);
+    this._commands[commandString] = command;
+    for (const alias of options.aliases || []) {
+      this._commands[alias] = command;
+    }
+    return command;
+  }
+
+  registerCommandAlias(alias, label) {
+    this._commands[alias] = this.commands[label];
+  }
+
+  createChannel(guildId, name, type, reason) {
+    expect(guildId).to.equal(this._guild.id);
+    let channel = channelFactory({ name, type, guild: this._guild });
+    this._auditLog.push(reason);
+    this._addChannel(channel);
+    return channel;
+  }
+
+  async getRESTGuilds() {
+    return [this._guild];
+  }
+
+  async getRESTGuildChannels(guildId) {
+    expect(guildId).to.equal(this._guild.id);
+    return this._channels;
+  }
+
+  async getChannel(channelId) {
+    return this._channels.find((c) => c.id == channelId);
+  }
+
+  async deleteChannel(channelId) {
+    this._channels = this._channels.filter((c) => c.id !== channelId);
+  }
+
+  async editChannel(channelId, newOpts) {
+    let index = this._channels.findIndex((c) => c.id == channelId);
+    this._channels[index] = { ...this._channels[index], ...newOpts };
   }
 }
 
-module.exports.MockBot = MockBot;
+class MockCommand {
+  constructor(callback, options) {
+    this._callback = callback;
+    this._options = options;
+    this._subcommands = {};
+
+    this.registerSubcommand = sinon.fake(this.registerSubcommand);
+  }
+
+  async trigger(msg, args = []) {
+    if (this._subcommands && args[0] in this._subcommands) {
+      return this._subcommands[args[0]].trigger(msg, args.slice(1));
+    } else if (typeof this._callback === 'string') {
+      return this._callback;
+    }
+    return await this._callback(msg, args);
+  }
+
+  registerSubcommand(commandString, callback, options) {
+    let command = new MockCommand(callback, options);
+    this._subcommands[commandString] = command;
+    return command;
+  }
+}
+
+module.exports = {
+  MockBot,
+  MockCommand,
+};

--- a/tests/voiceChannelManager.test.js
+++ b/tests/voiceChannelManager.test.js
@@ -1,0 +1,156 @@
+const chai = require('chai');
+const sinon = require('sinon');
+const sinonChai = require('sinon-chai');
+const faker = require('faker');
+
+const { MockBot } = require('./helpers/mockBot');
+const voiceChannelManager = require('../commands/voiceChannelManager');
+const { CHANNEL_TYPE } = require('../lib/constants');
+const { EMOJIS } = require('../commands/voiceChannelManager');
+
+chai.use(sinonChai);
+const expect = chai.expect;
+
+const CHANNEL_PREFIX = voiceChannelManager.EMOJIS.CHANNEL_PREFIX;
+
+describe('voiceChannelManager', () => {
+  beforeEach(() => {
+    sinon.useFakeTimers();
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  describe('!vc create', () => {
+    it('should create a voice channel', async () => {
+      const bot = new MockBot();
+      voiceChannelManager.register({ bot });
+      const { result, message } = await bot._triggerMessage('!vc create test channel');
+      expect(result).to.be.undefined;
+
+      expect(bot.createChannel).to.have.been.called;
+      expect(bot.createChannel.firstCall).to.be.calledWith(
+        bot._guild.id,
+        '⚡ AUTO CHANNELS',
+        CHANNEL_TYPE.GROUP,
+        sinon.match({ reason: sinon.match.string }),
+      );
+      expect(bot.createChannel.secondCall).to.be.calledWith(
+        bot._guild.id,
+        `${CHANNEL_PREFIX} test channel`,
+        CHANNEL_TYPE.VOICE,
+        sinon.match({ reason: sinon.match.string }),
+      );
+      expect(bot.addMessageReaction).to.be.calledWith(
+        message.channel.id,
+        message.id,
+        encodeURIComponent(EMOJIS.SUCCESS),
+      );
+    });
+
+    it('should reject channel names that are too long', async () => {
+      let tooLong = '';
+      while (tooLong.length < 100) {
+        tooLong += faker.lorem.sentences();
+      }
+
+      const bot = new MockBot();
+      voiceChannelManager.register({ bot });
+      const { result } = await bot._triggerMessage(`!vc create ${tooLong}`);
+      expect(result).to.be.a.string;
+      expect(bot.createChannel).to.not.be.called;
+    });
+  });
+
+  describe('!vc delete', () => {
+    it('should delete a channel that exists', async () => {
+      const bot = new MockBot({
+        channels: [
+          {
+            name: `${CHANNEL_PREFIX} AUTO CHANNELS`,
+            type: CHANNEL_TYPE.GROUP,
+          },
+        ],
+      });
+
+      const voiceChannel = bot._addChannel({
+        name: `${CHANNEL_PREFIX} ${faker.lorem.words(3)}`,
+        type: CHANNEL_TYPE.VOICE,
+      });
+      voiceChannelManager.register({ bot });
+      const { result, message } = await bot._triggerMessage(`!vc delete ${voiceChannel.name}`);
+      expect(result).to.be.undefined;
+      expect(bot.deleteChannel).to.be.calledWith(voiceChannel.id);
+      expect(bot.addMessageReaction).to.be.calledWith(
+        message.channel.id,
+        message.id,
+        encodeURIComponent(EMOJIS.SUCCESS),
+      );
+    });
+
+    it("should return an error if the channel can't be found", async () => {
+      const bot = new MockBot();
+      voiceChannelManager.register({ bot });
+      const { result } = bot._triggerMessage(`!vc delete a channel that does not exist`);
+      expect(result).to.be.a.string;
+      expect(bot.deleteChannel).not.to.have.been.called;
+    });
+  });
+
+  describe('!vc delete-all', () => {
+    it('should only print a warning', () => {
+      const bot = new MockBot();
+      voiceChannelManager.register({ bot });
+      const { result } = bot._triggerMessage(`!vc delete a channel that does not exist`);
+      expect(result).to.be.a.string;
+      expect(bot.deleteChannel).not.to.have.been.called;
+    });
+
+    it('should delete all the automatic channels with an emoji reaction', async () => {
+      const bot = new MockBot({
+        channels: [
+          { name: EMOJIS.CHANNEL_PREFIX + ' Delete voice', type: CHANNEL_TYPE.VOICE },
+          { name: EMOJIS.CHANNEL_PREFIX + ' Delete group', type: CHANNEL_TYPE.GROUP },
+          { name: EMOJIS.CHANNEL_PREFIX + ' Delete text', type: CHANNEL_TYPE.TEXT },
+          { name: 'Safe voice', type: CHANNEL_TYPE.VOICE },
+          { name: 'Safe group', type: CHANNEL_TYPE.GROUP },
+          { name: 'Safe text', type: CHANNEL_TYPE.TEXT },
+        ],
+      });
+      voiceChannelManager.register({ bot });
+      const reactionCommand = bot._commands['vc']._subcommands[
+        'delete-all'
+      ]._options.reactionButtons.find((r) => r.emoji === EMOJIS.CONFIRM_DELETE);
+      expect(reactionCommand).not.to.be.undefined;
+
+      let message = bot._makeMessage();
+      let reactionResult = await reactionCommand.response(message);
+      expect(reactionResult).to.be.a.string;
+      expect(bot.deleteChannel).to.have.been.calledThrice;
+      expect(bot._channels).to.have.length(3);
+    });
+  });
+
+  describe('cleanup task', () => {
+    it('should move channels through their life-cycle', async () => {
+      const bot = new MockBot({
+        channels: [
+          { name: EMOJIS.CHANNEL_PREFIX + ' managed', type: CHANNEL_TYPE.VOICE },
+          { name: 'unmanaged', type: CHANNEL_TYPE.VOICE },
+        ],
+      });
+      const channel = bot._channels.find((c) => c.name.startsWith(EMOJIS.CHANNEL_PREFIX));
+      const vc = voiceChannelManager.register({ bot });
+
+      await vc.cleanupTask();
+      expect(bot.editChannel).to.have.been.calledWith(channel.id, {
+        name: EMOJIS.CHANNEL_PREFIX + EMOJIS.CLEANUP + ' managed',
+      });
+
+      await vc.cleanupTask();
+      expect(bot.deleteChannel).to.have.been.calledWith(channel.id);
+      expect(bot._channels).to.have.length(1);
+    });
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,17 +2,133 @@
 # yarn lockfile v1
 
 
-"@babel/code-frame@^7.0.0":
+"@babel/code-frame@^7.0.0", "@babel/code-frame@^7.10.4":
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.10.4.tgz#168da1a36e90da68ae8d49c0f1b48c7c6249213a"
   integrity sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==
   dependencies:
     "@babel/highlight" "^7.10.4"
 
+"@babel/core@^7.7.5":
+  version "7.12.3"
+  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.12.3.tgz#1b436884e1e3bff6fb1328dc02b208759de92ad8"
+  integrity sha512-0qXcZYKZp3/6N2jKYVxZv0aNCsxTSVCiK72DTiTYZAu7sjg73W0/aynWjMbiGd87EQL4WyA8reiJVh92AVla9g==
+  dependencies:
+    "@babel/code-frame" "^7.10.4"
+    "@babel/generator" "^7.12.1"
+    "@babel/helper-module-transforms" "^7.12.1"
+    "@babel/helpers" "^7.12.1"
+    "@babel/parser" "^7.12.3"
+    "@babel/template" "^7.10.4"
+    "@babel/traverse" "^7.12.1"
+    "@babel/types" "^7.12.1"
+    convert-source-map "^1.7.0"
+    debug "^4.1.0"
+    gensync "^1.0.0-beta.1"
+    json5 "^2.1.2"
+    lodash "^4.17.19"
+    resolve "^1.3.2"
+    semver "^5.4.1"
+    source-map "^0.5.0"
+
+"@babel/generator@^7.12.1", "@babel/generator@^7.12.5":
+  version "7.12.5"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.12.5.tgz#a2c50de5c8b6d708ab95be5e6053936c1884a4de"
+  integrity sha512-m16TQQJ8hPt7E+OS/XVQg/7U184MLXtvuGbCdA7na61vha+ImkyyNM/9DDA0unYCVZn3ZOhng+qz48/KBOT96A==
+  dependencies:
+    "@babel/types" "^7.12.5"
+    jsesc "^2.5.1"
+    source-map "^0.5.0"
+
+"@babel/helper-function-name@^7.10.4":
+  version "7.10.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.10.4.tgz#d2d3b20c59ad8c47112fa7d2a94bc09d5ef82f1a"
+  integrity sha512-YdaSyz1n8gY44EmN7x44zBn9zQ1Ry2Y+3GTA+3vH6Mizke1Vw0aWDM66FOYEPw8//qKkmqOckrGgTYa+6sceqQ==
+  dependencies:
+    "@babel/helper-get-function-arity" "^7.10.4"
+    "@babel/template" "^7.10.4"
+    "@babel/types" "^7.10.4"
+
+"@babel/helper-get-function-arity@^7.10.4":
+  version "7.10.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-get-function-arity/-/helper-get-function-arity-7.10.4.tgz#98c1cbea0e2332f33f9a4661b8ce1505b2c19ba2"
+  integrity sha512-EkN3YDB+SRDgiIUnNgcmiD361ti+AVbL3f3Henf6dqqUyr5dMsorno0lJWJuLhDhkI5sYEpgj6y9kB8AOU1I2A==
+  dependencies:
+    "@babel/types" "^7.10.4"
+
+"@babel/helper-member-expression-to-functions@^7.12.1":
+  version "7.12.1"
+  resolved "https://registry.yarnpkg.com/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.12.1.tgz#fba0f2fcff3fba00e6ecb664bb5e6e26e2d6165c"
+  integrity sha512-k0CIe3tXUKTRSoEx1LQEPFU9vRQfqHtl+kf8eNnDqb4AUJEy5pz6aIiog+YWtVm2jpggjS1laH68bPsR+KWWPQ==
+  dependencies:
+    "@babel/types" "^7.12.1"
+
+"@babel/helper-module-imports@^7.12.1":
+  version "7.12.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.12.5.tgz#1bfc0229f794988f76ed0a4d4e90860850b54dfb"
+  integrity sha512-SR713Ogqg6++uexFRORf/+nPXMmWIn80TALu0uaFb+iQIUoR7bOC7zBWyzBs5b3tBBJXuyD0cRu1F15GyzjOWA==
+  dependencies:
+    "@babel/types" "^7.12.5"
+
+"@babel/helper-module-transforms@^7.12.1":
+  version "7.12.1"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.12.1.tgz#7954fec71f5b32c48e4b303b437c34453fd7247c"
+  integrity sha512-QQzehgFAZ2bbISiCpmVGfiGux8YVFXQ0abBic2Envhej22DVXV9nCFaS5hIQbkyo1AdGb+gNME2TSh3hYJVV/w==
+  dependencies:
+    "@babel/helper-module-imports" "^7.12.1"
+    "@babel/helper-replace-supers" "^7.12.1"
+    "@babel/helper-simple-access" "^7.12.1"
+    "@babel/helper-split-export-declaration" "^7.11.0"
+    "@babel/helper-validator-identifier" "^7.10.4"
+    "@babel/template" "^7.10.4"
+    "@babel/traverse" "^7.12.1"
+    "@babel/types" "^7.12.1"
+    lodash "^4.17.19"
+
+"@babel/helper-optimise-call-expression@^7.10.4":
+  version "7.10.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.10.4.tgz#50dc96413d594f995a77905905b05893cd779673"
+  integrity sha512-n3UGKY4VXwXThEiKrgRAoVPBMqeoPgHVqiHZOanAJCG9nQUL2pLRQirUzl0ioKclHGpGqRgIOkgcIJaIWLpygg==
+  dependencies:
+    "@babel/types" "^7.10.4"
+
+"@babel/helper-replace-supers@^7.12.1":
+  version "7.12.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-replace-supers/-/helper-replace-supers-7.12.5.tgz#f009a17543bbbbce16b06206ae73b63d3fca68d9"
+  integrity sha512-5YILoed0ZyIpF4gKcpZitEnXEJ9UoDRki1Ey6xz46rxOzfNMAhVIJMoune1hmPVxh40LRv1+oafz7UsWX+vyWA==
+  dependencies:
+    "@babel/helper-member-expression-to-functions" "^7.12.1"
+    "@babel/helper-optimise-call-expression" "^7.10.4"
+    "@babel/traverse" "^7.12.5"
+    "@babel/types" "^7.12.5"
+
+"@babel/helper-simple-access@^7.12.1":
+  version "7.12.1"
+  resolved "https://registry.yarnpkg.com/@babel/helper-simple-access/-/helper-simple-access-7.12.1.tgz#32427e5aa61547d38eb1e6eaf5fd1426fdad9136"
+  integrity sha512-OxBp7pMrjVewSSC8fXDFrHrBcJATOOFssZwv16F3/6Xtc138GHybBfPbm9kfiqQHKhYQrlamWILwlDCeyMFEaA==
+  dependencies:
+    "@babel/types" "^7.12.1"
+
+"@babel/helper-split-export-declaration@^7.11.0":
+  version "7.11.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.11.0.tgz#f8a491244acf6a676158ac42072911ba83ad099f"
+  integrity sha512-74Vejvp6mHkGE+m+k5vHY93FX2cAtrw1zXrZXRlG4l410Nm9PxfEiVTn1PjDPV5SnmieiueY4AFg2xqhNFuuZg==
+  dependencies:
+    "@babel/types" "^7.11.0"
+
 "@babel/helper-validator-identifier@^7.10.4":
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz#a78c7a7251e01f616512d31b10adcf52ada5e0d2"
   integrity sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw==
+
+"@babel/helpers@^7.12.1":
+  version "7.12.5"
+  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.12.5.tgz#1a1ba4a768d9b58310eda516c449913fe647116e"
+  integrity sha512-lgKGMQlKqA8meJqKsW6rUnc4MdUk35Ln0ATDqdM1a/UpARODdI4j5Y5lVfUScnSNkJcdCRAaWkspykNoFg9sJA==
+  dependencies:
+    "@babel/template" "^7.10.4"
+    "@babel/traverse" "^7.12.5"
+    "@babel/types" "^7.12.5"
 
 "@babel/highlight@^7.10.4":
   version "7.10.4"
@@ -23,10 +139,100 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
+"@babel/parser@^7.10.4", "@babel/parser@^7.12.3", "@babel/parser@^7.12.5":
+  version "7.12.5"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.12.5.tgz#b4af32ddd473c0bfa643bd7ff0728b8e71b81ea0"
+  integrity sha512-FVM6RZQ0mn2KCf1VUED7KepYeUWoVShczewOCfm3nzoBybaih51h+sYVVGthW9M6lPByEPTQf+xm27PBdlpwmQ==
+
+"@babel/template@^7.10.4":
+  version "7.10.4"
+  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.10.4.tgz#3251996c4200ebc71d1a8fc405fba940f36ba278"
+  integrity sha512-ZCjD27cGJFUB6nmCB1Enki3r+L5kJveX9pq1SvAUKoICy6CZ9yD8xO086YXdYhvNjBdnekm4ZnaP5yC8Cs/1tA==
+  dependencies:
+    "@babel/code-frame" "^7.10.4"
+    "@babel/parser" "^7.10.4"
+    "@babel/types" "^7.10.4"
+
+"@babel/traverse@^7.12.1", "@babel/traverse@^7.12.5":
+  version "7.12.5"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.12.5.tgz#78a0c68c8e8a35e4cacfd31db8bb303d5606f095"
+  integrity sha512-xa15FbQnias7z9a62LwYAA5SZZPkHIXpd42C6uW68o8uTuua96FHZy1y61Va5P/i83FAAcMpW8+A/QayntzuqA==
+  dependencies:
+    "@babel/code-frame" "^7.10.4"
+    "@babel/generator" "^7.12.5"
+    "@babel/helper-function-name" "^7.10.4"
+    "@babel/helper-split-export-declaration" "^7.11.0"
+    "@babel/parser" "^7.12.5"
+    "@babel/types" "^7.12.5"
+    debug "^4.1.0"
+    globals "^11.1.0"
+    lodash "^4.17.19"
+
+"@babel/types@^7.10.4", "@babel/types@^7.11.0", "@babel/types@^7.12.1", "@babel/types@^7.12.5":
+  version "7.12.5"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.12.5.tgz#5d6b4590cfe90c0c8d7396c83ffd9fc28b5a6450"
+  integrity sha512-gyTcvz7JFa4V45C0Zklv//GmFOAal5fL23OWpBLqc4nZ4Yrz67s4kCNwSK1Gu0MXGTU8mRY3zJYtacLdKXlzig==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.10.4"
+    lodash "^4.17.19"
+    to-fast-properties "^2.0.0"
+
 "@fluent/bundle@^0.16.0":
   version "0.16.0"
   resolved "https://registry.yarnpkg.com/@fluent/bundle/-/bundle-0.16.0.tgz#e0cab75ba6ce9d9147ace3cb6ec61fd90f31ec1f"
   integrity sha512-kUEAUePhb/y2BCcNpKOnjCs+WJkDczVpUUAQ+cDl0xvBGqL0Kv0Yog2oHSuv/Ou22c6KdXbvfCl3We0bIZnrmg==
+
+"@istanbuljs/load-nyc-config@^1.0.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz#fd3db1d59ecf7cf121e80650bb86712f9b55eced"
+  integrity sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ==
+  dependencies:
+    camelcase "^5.3.1"
+    find-up "^4.1.0"
+    get-package-type "^0.1.0"
+    js-yaml "^3.13.1"
+    resolve-from "^5.0.0"
+
+"@istanbuljs/schema@^0.1.2":
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/@istanbuljs/schema/-/schema-0.1.2.tgz#26520bf09abe4a5644cd5414e37125a8954241dd"
+  integrity sha512-tsAQNx32a8CoFhjhijUIhI4kccIAgmGhy8LZMZgGfmXcpMbPRUqn5LWmgRttILi6yeGmBJd2xsPkFMs0PzgPCw==
+
+"@sinonjs/commons@^1", "@sinonjs/commons@^1.6.0", "@sinonjs/commons@^1.7.0", "@sinonjs/commons@^1.8.1":
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.8.1.tgz#e7df00f98a203324f6dc7cc606cad9d4a8ab2217"
+  integrity sha512-892K+kWUUi3cl+LlqEWIDrhvLgdL79tECi8JZUyq6IviKy/DNhuzCRlbHUjxK89f4ypPMMaFnFuR9Ie6DoIMsw==
+  dependencies:
+    type-detect "4.0.8"
+
+"@sinonjs/fake-timers@^6.0.0", "@sinonjs/fake-timers@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/@sinonjs/fake-timers/-/fake-timers-6.0.1.tgz#293674fccb3262ac782c7aadfdeca86b10c75c40"
+  integrity sha512-MZPUxrmFubI36XS1DI3qmI0YdN1gks62JtFZvxR67ljjSNCeK6U08Zx4msEWOXuofgqUt6zPHSi1H9fbjR/NRA==
+  dependencies:
+    "@sinonjs/commons" "^1.7.0"
+
+"@sinonjs/formatio@^5.0.1":
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/@sinonjs/formatio/-/formatio-5.0.1.tgz#f13e713cb3313b1ab965901b01b0828ea6b77089"
+  integrity sha512-KaiQ5pBf1MpS09MuA0kp6KBQt2JUOQycqVG1NZXvzeaXe5LGFqAKueIS0bw4w0P9r7KuBSVdUk5QjXsUdu2CxQ==
+  dependencies:
+    "@sinonjs/commons" "^1"
+    "@sinonjs/samsam" "^5.0.2"
+
+"@sinonjs/samsam@^5.0.2", "@sinonjs/samsam@^5.2.0":
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/@sinonjs/samsam/-/samsam-5.2.0.tgz#fcff83ab86f83b5498f4a967869c079408d9b5eb"
+  integrity sha512-CaIcyX5cDsjcW/ab7HposFWzV1kC++4HNsfnEdFJa7cP1QIuILAKV+BgfeqRXhcnSAc76r/Rh/O5C+300BwUIw==
+  dependencies:
+    "@sinonjs/commons" "^1.6.0"
+    lodash.get "^4.4.2"
+    type-detect "^4.0.8"
+
+"@sinonjs/text-encoding@^0.7.1":
+  version "0.7.1"
+  resolved "https://registry.yarnpkg.com/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz#8da5c6530915653f3a1f38fd5f101d8c3f8079c5"
+  integrity sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==
 
 "@types/color-name@^1.1.1":
   version "1.1.1"
@@ -116,6 +322,18 @@ anymatch@~3.1.1:
     normalize-path "^3.0.0"
     picomatch "^2.0.4"
 
+append-transform@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/append-transform/-/append-transform-2.0.0.tgz#99d9d29c7b38391e6f428d28ce136551f0b77e12"
+  integrity sha512-7yeyCEurROLQJFv5Xj4lEGTy0borxepjFv1g22oAdqFu//SrAlDl1O1Nxx15SH1RoliUml6p8dwJW9jvZughhg==
+  dependencies:
+    default-require-extensions "^3.0.0"
+
+archy@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/archy/-/archy-1.0.0.tgz#f9c8c13757cc1dd7bc379ac77b2c62a5c2868c40"
+  integrity sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=
+
 argparse@^1.0.7:
   version "1.0.10"
   resolved "https://registry.yarnpkg.com/argparse/-/argparse-1.0.10.tgz#bcd6791ea5ae09725e17e5ad988134cd40b3d911"
@@ -177,6 +395,16 @@ browser-stdout@1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/browser-stdout/-/browser-stdout-1.3.1.tgz#baa559ee14ced73452229bad7326467c61fabd60"
   integrity sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==
+
+caching-transform@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/caching-transform/-/caching-transform-4.0.0.tgz#00d297a4206d71e2163c39eaffa8157ac0651f0f"
+  integrity sha512-kpqOvwXnjjN44D89K5ccQC+RUrsy7jB/XLlRrx0D7/2HNcTPqzsb6XgYoErwko6QsV184CA2YgS1fxDiiDZMWA==
+  dependencies:
+    hasha "^5.0.0"
+    make-dir "^3.0.0"
+    package-hash "^4.0.0"
+    write-file-atomic "^3.0.0"
 
 callsites@^3.0.0:
   version "3.1.0"
@@ -271,6 +499,15 @@ cliui@^5.0.0:
     strip-ansi "^5.2.0"
     wrap-ansi "^5.1.0"
 
+cliui@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/cliui/-/cliui-6.0.0.tgz#511d702c0c4e41ca156d7d0e96021f23e13225b1"
+  integrity sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==
+  dependencies:
+    string-width "^4.2.0"
+    strip-ansi "^6.0.0"
+    wrap-ansi "^6.2.0"
+
 color-convert@^1.9.0:
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.3.tgz#bb71850690e1f136567de629d2d5471deda4c1e8"
@@ -300,6 +537,11 @@ commander@^5.1.0:
   resolved "https://registry.yarnpkg.com/commander/-/commander-5.1.0.tgz#46abbd1652f8e059bddaef99bbdcb2ad9cf179ae"
   integrity sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==
 
+commondir@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/commondir/-/commondir-1.0.1.tgz#ddd800da0c66127393cca5950ea968a3aaf1253b"
+  integrity sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=
+
 compare-versions@^3.6.0:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/compare-versions/-/compare-versions-3.6.0.tgz#1a5689913685e5a87637b8d3ffca75514ec41d62"
@@ -309,6 +551,13 @@ concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
   integrity sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=
+
+convert-source-map@^1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.7.0.tgz#17a2cb882d7f77d3490585e2ce6c524424a3a442"
+  integrity sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==
+  dependencies:
+    safe-buffer "~5.1.1"
 
 cosmiconfig@^6.0.0:
   version "6.0.0"
@@ -337,6 +586,13 @@ debug@4.1.1, debug@^4.0.1, debug@^4.1.1:
   dependencies:
     ms "^2.1.1"
 
+debug@^4.1.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.2.0.tgz#7f150f93920e94c58f5574c2fd01a3110effe7f1"
+  integrity sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==
+  dependencies:
+    ms "2.1.2"
+
 decamelize@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
@@ -359,6 +615,13 @@ deep-is@^0.1.3:
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
   integrity sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=
 
+default-require-extensions@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/default-require-extensions/-/default-require-extensions-3.0.0.tgz#e03f93aac9b2b6443fc52e5e4a37b3ad9ad8df96"
+  integrity sha512-ek6DpXq/SCpvjhpFsLFRVtIxJCRw6fUR42lYMVZuUMK7n8eMz4Uh5clckdBjEpLhn/gEBZo7hDJnJcwdKLKQjg==
+  dependencies:
+    strip-bom "^4.0.0"
+
 define-properties@^1.1.2, define-properties@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/define-properties/-/define-properties-1.1.3.tgz#cf88da6cbee26fe6db7094f61d870cbd84cee9f1"
@@ -366,7 +629,7 @@ define-properties@^1.1.2, define-properties@^1.1.3:
   dependencies:
     object-keys "^1.0.12"
 
-diff@4.0.2:
+diff@4.0.2, diff@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/diff/-/diff-4.0.2.tgz#60f3aecb89d5fae520c11aa19efc2bb982aade7d"
   integrity sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==
@@ -467,6 +730,11 @@ es-to-primitive@^1.2.1:
     is-callable "^1.1.4"
     is-date-object "^1.0.1"
     is-symbol "^1.0.2"
+
+es6-error@^4.0.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/es6-error/-/es6-error-4.1.1.tgz#9e3af407459deed47e9a91f9b885a84eb05c561d"
+  integrity sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==
 
 escape-string-regexp@4.0.0:
   version "4.0.0"
@@ -612,6 +880,11 @@ execa@^4.0.1:
     signal-exit "^3.0.2"
     strip-final-newline "^2.0.0"
 
+faker@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/faker/-/faker-5.1.0.tgz#e10fa1dec4502551aee0eb771617a7e7b94692e8"
+  integrity sha512-RrWKFSSA/aNLP0g3o2WW1Zez7/MnMr7xkiZmoCfAGZmdkDQZ6l2KtuXHN5XjdvpRjDl8+3vf+Rrtl06Z352+Mw==
+
 fast-deep-equal@^3.1.1:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
@@ -653,6 +926,15 @@ fill-range@^7.0.1:
   dependencies:
     to-regex-range "^5.0.1"
 
+find-cache-dir@^3.2.0:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/find-cache-dir/-/find-cache-dir-3.3.1.tgz#89b33fad4a4670daa94f855f7fbe31d6d84fe880"
+  integrity sha512-t2GDMt3oGC/v+BMwzmllWDuJF/xcDtE5j/fCGbqDD7OLuJkj0cfh1YSA5VKPvwMeLFLNDBkwOKZ2X85jGLVftQ==
+  dependencies:
+    commondir "^1.0.1"
+    make-dir "^3.0.2"
+    pkg-dir "^4.1.0"
+
 find-up@5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/find-up/-/find-up-5.0.0.tgz#4c92819ecb7083561e4f4a240a86be5198f536fc"
@@ -668,7 +950,7 @@ find-up@^3.0.0:
   dependencies:
     locate-path "^3.0.0"
 
-find-up@^4.0.0:
+find-up@^4.0.0, find-up@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/find-up/-/find-up-4.1.0.tgz#97afe7d6cdc0bc5928584b7c8d7b16e8a9aa5d19"
   integrity sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==
@@ -704,6 +986,19 @@ flatted@^2.0.0:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-2.0.2.tgz#4575b21e2bcee7434aa9be662f4b7b5f9c2b5138"
   integrity sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==
 
+foreground-child@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/foreground-child/-/foreground-child-2.0.0.tgz#71b32800c9f15aa8f2f83f4a6bd9bff35d861a53"
+  integrity sha512-dCIq9FpEcyQyXKCkyzmlPTFNgrCzPudOe+mhvJU5zAtlBnGVy2yKxtfsxK2tQBThwq225jcvBjpw1Gr40uzZCA==
+  dependencies:
+    cross-spawn "^7.0.0"
+    signal-exit "^3.0.2"
+
+fromentries@^1.2.0:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/fromentries/-/fromentries-1.3.1.tgz#b14c6d4d606c771ce85597f13794fb10200a0ccc"
+  integrity sha512-w4t/zm2J+uAcrpeKyW0VmYiIs3aqe/xKQ+2qwazVNZSCklQHhaVjk6XzKw5GtImq5thgL0IVRjGRAOastb08RQ==
+
 fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
@@ -724,6 +1019,11 @@ functional-red-black-tree@^1.0.1:
   resolved "https://registry.yarnpkg.com/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz#1b0ab3bd553b2a0d6399d29c0e3ea0b252078327"
   integrity sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=
 
+gensync@^1.0.0-beta.1:
+  version "1.0.0-beta.2"
+  resolved "https://registry.yarnpkg.com/gensync/-/gensync-1.0.0-beta.2.tgz#32a6ee76c3d7f52d46b2b1ae5d93fea8580a25e0"
+  integrity sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==
+
 get-caller-file@^2.0.1:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
@@ -738,6 +1038,11 @@ get-own-enumerable-property-symbols@^3.0.0:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-3.0.2.tgz#b5fde77f22cbe35f390b4e089922c50bce6ef664"
   integrity sha512-I0UBV/XOz1XkIJHEUDMZAbzCThU/H8DxmSfmdGcKPnVhu2VfFqr34jr9777IyaTYvxjedWhqVIilEDsCdP5G6g==
+
+get-package-type@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/get-package-type/-/get-package-type-0.1.0.tgz#8de2d803cff44df3bc6c456e6668b36c3926e11a"
+  integrity sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==
 
 get-stdin@^6.0.0:
   version "6.0.0"
@@ -758,7 +1063,7 @@ glob-parent@^5.0.0, glob-parent@~5.1.0:
   dependencies:
     is-glob "^4.0.1"
 
-glob@7.1.6, glob@^7.1.3:
+glob@7.1.6, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6:
   version "7.1.6"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.6.tgz#141f33b81a7c2492e125594307480c46679278a6"
   integrity sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==
@@ -770,12 +1075,22 @@ glob@7.1.6, glob@^7.1.3:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
+globals@^11.1.0:
+  version "11.12.0"
+  resolved "https://registry.yarnpkg.com/globals/-/globals-11.12.0.tgz#ab8795338868a0babd8525758018c2a7eb95c42e"
+  integrity sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==
+
 globals@^12.1.0:
   version "12.4.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-12.4.0.tgz#a18813576a41b00a24a97e7f815918c2e19925f8"
   integrity sha512-BWICuzzDvDoH54NHKCseDanAhE3CeDorgDL5MT6LMXXj2WCnd9UC2szdk4AWLfjdgNBCXLUanXYcpBBKOSWGwg==
   dependencies:
     type-fest "^0.8.1"
+
+graceful-fs@^4.1.15:
+  version "4.2.4"
+  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.4.tgz#2256bde14d3632958c465ebc96dc467ca07a29fb"
+  integrity sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==
 
 growl@1.10.5:
   version "1.10.5"
@@ -804,10 +1119,23 @@ has@^1.0.3:
   dependencies:
     function-bind "^1.1.1"
 
+hasha@^5.0.0:
+  version "5.2.2"
+  resolved "https://registry.yarnpkg.com/hasha/-/hasha-5.2.2.tgz#a48477989b3b327aea3c04f53096d816d97522a1"
+  integrity sha512-Hrp5vIK/xr5SkeN2onO32H0MgNZ0f17HRNH39WfL0SYUNOTZ5Lz1TJ8Pajo/87dYGEFlLMm7mIc/k/s6Bvz9HQ==
+  dependencies:
+    is-stream "^2.0.0"
+    type-fest "^0.8.0"
+
 he@1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
   integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
+
+html-escaper@^2.0.0:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/html-escaper/-/html-escaper-2.0.2.tgz#dfd60027da36a36dfcbe236262c00a5822681453"
+  integrity sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==
 
 human-signals@^1.1.1:
   version "1.1.1"
@@ -893,6 +1221,13 @@ is-callable@^1.1.4, is-callable@^1.2.0:
   resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.2.0.tgz#83336560b54a38e35e3a2df7afd0454d691468bb"
   integrity sha512-pyVD9AaGLxtg6srb2Ng6ynWJqkHU9bEM087AKck0w8QwDarTfNcpIYoU8x8Hv2Icm8u6kFJM18Dag8lyqGkviw==
 
+is-core-module@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.0.0.tgz#58531b70aed1db7c0e8d4eb1a0a2d1ddd64bd12d"
+  integrity sha512-jq1AH6C8MuteOoBPwkxHafmByhL9j5q4OaPGdbuD+ZtQJVzH+i6E3BJDQcBA09k57i2Hh2yQbEG8yObZ0jdlWw==
+  dependencies:
+    has "^1.0.3"
+
 is-date-object@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-date-object/-/is-date-object-1.0.2.tgz#bda736f2cd8fd06d32844e7743bfa7494c3bfd7e"
@@ -974,6 +1309,21 @@ is-symbol@^1.0.2:
   dependencies:
     has-symbols "^1.0.1"
 
+is-typedarray@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-typedarray/-/is-typedarray-1.0.0.tgz#e479c80858df0c1b11ddda6940f96011fcda4a9a"
+  integrity sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=
+
+is-windows@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-1.0.2.tgz#d1850eb9791ecd18e6182ce12a30f396634bb19d"
+  integrity sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==
+
+isarray@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/isarray/-/isarray-0.0.1.tgz#8a18acfca9a8f4177e09abfc6038939b05d1eedf"
+  integrity sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=
+
 isarray@^2.0.5:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-2.0.5.tgz#8af1e4c1221244cc62459faf38940d4e644a5723"
@@ -983,6 +1333,67 @@ isexe@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
   integrity sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=
+
+istanbul-lib-coverage@^3.0.0, istanbul-lib-coverage@^3.0.0-alpha.1:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-coverage/-/istanbul-lib-coverage-3.0.0.tgz#f5944a37c70b550b02a78a5c3b2055b280cec8ec"
+  integrity sha512-UiUIqxMgRDET6eR+o5HbfRYP1l0hqkWOs7vNxC/mggutCMUIhWMm8gAHb8tHlyfD3/l6rlgNA5cKdDzEAf6hEg==
+
+istanbul-lib-hook@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-hook/-/istanbul-lib-hook-3.0.0.tgz#8f84c9434888cc6b1d0a9d7092a76d239ebf0cc6"
+  integrity sha512-Pt/uge1Q9s+5VAZ+pCo16TYMWPBIl+oaNIjgLQxcX0itS6ueeaA+pEfThZpH8WxhFgCiEb8sAJY6MdUKgiIWaQ==
+  dependencies:
+    append-transform "^2.0.0"
+
+istanbul-lib-instrument@^4.0.0:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-instrument/-/istanbul-lib-instrument-4.0.3.tgz#873c6fff897450118222774696a3f28902d77c1d"
+  integrity sha512-BXgQl9kf4WTCPCCpmFGoJkz/+uhvm7h7PFKUYxh7qarQd3ER33vHG//qaE8eN25l07YqZPpHXU9I09l/RD5aGQ==
+  dependencies:
+    "@babel/core" "^7.7.5"
+    "@istanbuljs/schema" "^0.1.2"
+    istanbul-lib-coverage "^3.0.0"
+    semver "^6.3.0"
+
+istanbul-lib-processinfo@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-processinfo/-/istanbul-lib-processinfo-2.0.2.tgz#e1426514662244b2f25df728e8fd1ba35fe53b9c"
+  integrity sha512-kOwpa7z9hme+IBPZMzQ5vdQj8srYgAtaRqeI48NGmAQ+/5yKiHLV0QbYqQpxsdEF0+w14SoB8YbnHKcXE2KnYw==
+  dependencies:
+    archy "^1.0.0"
+    cross-spawn "^7.0.0"
+    istanbul-lib-coverage "^3.0.0-alpha.1"
+    make-dir "^3.0.0"
+    p-map "^3.0.0"
+    rimraf "^3.0.0"
+    uuid "^3.3.3"
+
+istanbul-lib-report@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-report/-/istanbul-lib-report-3.0.0.tgz#7518fe52ea44de372f460a76b5ecda9ffb73d8a6"
+  integrity sha512-wcdi+uAKzfiGT2abPpKZ0hSU1rGQjUQnLvtY5MpQ7QCTahD3VODhcu4wcfY1YtkGaDD5yuydOLINXsfbus9ROw==
+  dependencies:
+    istanbul-lib-coverage "^3.0.0"
+    make-dir "^3.0.0"
+    supports-color "^7.1.0"
+
+istanbul-lib-source-maps@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-source-maps/-/istanbul-lib-source-maps-4.0.0.tgz#75743ce6d96bb86dc7ee4352cf6366a23f0b1ad9"
+  integrity sha512-c16LpFRkR8vQXyHZ5nLpY35JZtzj1PQY1iZmesUbf1FZHbIupcWfjgOXBY9YHkLEQ6puz1u4Dgj6qmU/DisrZg==
+  dependencies:
+    debug "^4.1.1"
+    istanbul-lib-coverage "^3.0.0"
+    source-map "^0.6.1"
+
+istanbul-reports@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/istanbul-reports/-/istanbul-reports-3.0.2.tgz#d593210e5000683750cb09fc0644e4b6e27fd53b"
+  integrity sha512-9tZvz7AiR3PEDNGiV9vIouQ/EAcqMXFmkcA1CDFTwOB98OZVDL0PH9glHotf5Ugp6GCOTypfzGWI/OqjWNCRUw==
+  dependencies:
+    html-escaper "^2.0.0"
+    istanbul-lib-report "^3.0.0"
 
 iterate-iterator@^1.0.1:
   version "1.0.1"
@@ -1010,6 +1421,11 @@ js-yaml@3.14.0, js-yaml@^3.13.1:
     argparse "^1.0.7"
     esprima "^4.0.0"
 
+jsesc@^2.5.1:
+  version "2.5.2"
+  resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-2.5.2.tgz#80564d2e483dacf6e8ef209650a67df3f0c283a4"
+  integrity sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==
+
 json-parse-better-errors@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz#bb867cfb3450e69107c131d1c514bab3dc8bcaa9"
@@ -1024,6 +1440,18 @@ json-stable-stringify-without-jsonify@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
   integrity sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=
+
+json5@^2.1.2:
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/json5/-/json5-2.1.3.tgz#c9b0f7fa9233bfe5807fe66fcf3a5617ed597d43"
+  integrity sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==
+  dependencies:
+    minimist "^1.2.5"
+
+just-extend@^4.0.2:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/just-extend/-/just-extend-4.1.1.tgz#158f1fdb01f128c411dc8b286a7b4837b3545282"
+  integrity sha512-aWgeGFW67BP3e5181Ep1Fv2v8z//iBJfrvyTnq8wG86vEESwmonn1zPBJ0VfmT9CJq2FIT0VsETtrNFm2a+SHA==
 
 levn@^0.4.1:
   version "0.4.1"
@@ -1095,6 +1523,16 @@ locate-path@^6.0.0:
   dependencies:
     p-locate "^5.0.0"
 
+lodash.flattendeep@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz#fb030917f86a3134e5bc9bec0d69e0013ddfedb2"
+  integrity sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=
+
+lodash.get@^4.4.2:
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
+  integrity sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=
+
 lodash@^4.17.14, lodash@^4.17.19:
   version "4.17.20"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
@@ -1116,6 +1554,13 @@ log-update@^4.0.0:
     cli-cursor "^3.1.0"
     slice-ansi "^4.0.0"
     wrap-ansi "^6.2.0"
+
+make-dir@^3.0.0, make-dir@^3.0.2:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-3.1.0.tgz#415e967046b3a7f1d185277d84aa58203726a13f"
+  integrity sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==
+  dependencies:
+    semver "^6.0.0"
 
 merge-stream@^2.0.0:
   version "2.0.0"
@@ -1195,10 +1640,28 @@ natural-compare@^1.4.0:
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=
 
+nise@^4.0.4:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/nise/-/nise-4.0.4.tgz#d73dea3e5731e6561992b8f570be9e363c4512dd"
+  integrity sha512-bTTRUNlemx6deJa+ZyoCUTRvH3liK5+N6VQZ4NIw90AgDXY6iPnsqplNFf6STcj+ePk0H/xqxnP75Lr0J0Fq3A==
+  dependencies:
+    "@sinonjs/commons" "^1.7.0"
+    "@sinonjs/fake-timers" "^6.0.0"
+    "@sinonjs/text-encoding" "^0.7.1"
+    just-extend "^4.0.2"
+    path-to-regexp "^1.7.0"
+
 node-fetch@^2.6.1:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
   integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
+
+node-preload@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/node-preload/-/node-preload-0.2.1.tgz#c03043bb327f417a18fee7ab7ee57b408a144301"
+  integrity sha512-RM5oyBy45cLEoHqCeh+MNuFAxO0vTFBLskvQbOKnEE7YTTSN4tbN8QWDIPQ6L+WvKsB/qLEGpYe2ZZ9d4W9OIQ==
+  dependencies:
+    process-on-spawn "^1.0.0"
 
 normalize-path@^3.0.0, normalize-path@~3.0.0:
   version "3.0.0"
@@ -1211,6 +1674,39 @@ npm-run-path@^4.0.0:
   integrity sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==
   dependencies:
     path-key "^3.0.0"
+
+nyc@^15.1.0:
+  version "15.1.0"
+  resolved "https://registry.yarnpkg.com/nyc/-/nyc-15.1.0.tgz#1335dae12ddc87b6e249d5a1994ca4bdaea75f02"
+  integrity sha512-jMW04n9SxKdKi1ZMGhvUTHBN0EICCRkHemEoE5jm6mTYcqcdas0ATzgUgejlQUHMvpnOZqGB5Xxsv9KxJW1j8A==
+  dependencies:
+    "@istanbuljs/load-nyc-config" "^1.0.0"
+    "@istanbuljs/schema" "^0.1.2"
+    caching-transform "^4.0.0"
+    convert-source-map "^1.7.0"
+    decamelize "^1.2.0"
+    find-cache-dir "^3.2.0"
+    find-up "^4.1.0"
+    foreground-child "^2.0.0"
+    get-package-type "^0.1.0"
+    glob "^7.1.6"
+    istanbul-lib-coverage "^3.0.0"
+    istanbul-lib-hook "^3.0.0"
+    istanbul-lib-instrument "^4.0.0"
+    istanbul-lib-processinfo "^2.0.2"
+    istanbul-lib-report "^3.0.0"
+    istanbul-lib-source-maps "^4.0.0"
+    istanbul-reports "^3.0.2"
+    make-dir "^3.0.0"
+    node-preload "^0.2.1"
+    p-map "^3.0.0"
+    process-on-spawn "^1.0.0"
+    resolve-from "^5.0.0"
+    rimraf "^3.0.0"
+    signal-exit "^3.0.2"
+    spawn-wrap "^2.0.0"
+    test-exclude "^6.0.0"
+    yargs "^15.0.2"
 
 object-inspect@^1.7.0:
   version "1.8.0"
@@ -1303,6 +1799,13 @@ p-locate@^5.0.0:
   dependencies:
     p-limit "^3.0.2"
 
+p-map@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/p-map/-/p-map-3.0.0.tgz#d704d9af8a2ba684e2600d9a215983d4141a979d"
+  integrity sha512-d3qXVTF/s+W+CdJ5A29wywV2n8CQQYahlgz2bFiA+4eVNJbHJodPZ+/gXwPGh0bOqA+j8S+6+ckmvLGPk1QpxQ==
+  dependencies:
+    aggregate-error "^3.0.0"
+
 p-map@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/p-map/-/p-map-4.0.0.tgz#bb2f95a5eda2ec168ec9274e06a747c3e2904d2b"
@@ -1314,6 +1817,16 @@ p-try@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/p-try/-/p-try-2.2.0.tgz#cb2868540e313d61de58fafbe35ce9004d5540e6"
   integrity sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==
+
+package-hash@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/package-hash/-/package-hash-4.0.0.tgz#3537f654665ec3cc38827387fc904c163c54f506"
+  integrity sha512-whdkPIooSu/bASggZ96BWVvZTRMOFxnyUG5PnTSGKoJE2gd5mbVNmR2Nj20QFzxYYgAXpoqC+AiXzl+UMRh7zQ==
+  dependencies:
+    graceful-fs "^4.1.15"
+    hasha "^5.0.0"
+    lodash.flattendeep "^4.4.0"
+    release-zalgo "^1.0.0"
 
 parent-module@^1.0.0:
   version "1.0.1"
@@ -1352,6 +1865,18 @@ path-key@^3.0.0, path-key@^3.1.0:
   resolved "https://registry.yarnpkg.com/path-key/-/path-key-3.1.1.tgz#581f6ade658cbba65a0d3380de7753295054f375"
   integrity sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==
 
+path-parse@^1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.6.tgz#d62dbb5679405d72c4737ec58600e9ddcf06d24c"
+  integrity sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==
+
+path-to-regexp@^1.7.0:
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-1.8.0.tgz#887b3ba9d84393e87a0a0b9f4cb756198b53548a"
+  integrity sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==
+  dependencies:
+    isarray "0.0.1"
+
 path-type@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-4.0.0.tgz#84ed01c0a7ba380afe09d90a8c180dcd9d03043b"
@@ -1367,7 +1892,7 @@ picomatch@^2.0.4, picomatch@^2.0.5, picomatch@^2.2.1:
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.2.2.tgz#21f333e9b6b8eaff02468f5146ea406d345f4dad"
   integrity sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==
 
-pkg-dir@^4.2.0:
+pkg-dir@^4.1.0, pkg-dir@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/pkg-dir/-/pkg-dir-4.2.0.tgz#f099133df7ede422e81d1d8448270eeb3e4261f3"
   integrity sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==
@@ -1397,6 +1922,13 @@ prettier@^2.0.5:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.0.5.tgz#d6d56282455243f2f92cc1716692c08aa31522d4"
   integrity sha512-7PtVymN48hGcO4fGjybyBSIWDsLU4H4XlvOHfq91pz9kkGlonzwTfYkaIEwiRg/dAJF9YlbsduBAgtYLi+8cFg==
+
+process-on-spawn@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/process-on-spawn/-/process-on-spawn-1.0.0.tgz#95b05a23073d30a17acfdc92a440efd2baefdc93"
+  integrity sha512-1WsPDsUSMmZH5LeMLegqkPDrsGgsWwk1Exipy2hvB0o/F0ASzbpIctSCcZIK1ykJvtTJULEH+20WOFjMvGnCTg==
+  dependencies:
+    fromentries "^1.2.0"
 
 progress@^2.0.0:
   version "2.0.3"
@@ -1446,6 +1978,13 @@ regexpp@^3.1.0:
   resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-3.1.0.tgz#206d0ad0a5648cffbdb8ae46438f3dc51c9f78e2"
   integrity sha512-ZOIzd8yVsQQA7j8GCSlPGXwg5PfmA1mrq0JP4nGhh54LaKN3xdai/vHUDu74pKwV8OxseMS65u2NImosQcSD0Q==
 
+release-zalgo@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/release-zalgo/-/release-zalgo-1.0.0.tgz#09700b7e5074329739330e535c5a90fb67851730"
+  integrity sha1-CXALflB0Mpc5Mw5TXFqQ+2eFFzA=
+  dependencies:
+    es6-error "^4.0.1"
+
 require-directory@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
@@ -1460,6 +1999,19 @@ resolve-from@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-4.0.0.tgz#4abcd852ad32dd7baabfe9b40e00a36db5f392e6"
   integrity sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==
+
+resolve-from@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-5.0.0.tgz#c35225843df8f776df21c57557bc087e9dfdfc69"
+  integrity sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==
+
+resolve@^1.3.2:
+  version "1.18.1"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.18.1.tgz#018fcb2c5b207d2a6424aee361c5a266da8f4130"
+  integrity sha512-lDfCPaMKfOJXjy0dPayzPdF1phampNWr3qFCjAu+rw/qbQmr5jWH5xN2hwh9QKfw9E5v4hwV7A+jrCmL8yjjqA==
+  dependencies:
+    is-core-module "^2.0.0"
+    path-parse "^1.0.6"
 
 restore-cursor@^3.1.0:
   version "3.1.0"
@@ -1476,6 +2028,13 @@ rimraf@2.6.3:
   dependencies:
     glob "^7.1.3"
 
+rimraf@^3.0.0:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
+  integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
+  dependencies:
+    glob "^7.1.3"
+
 rxjs@^6.6.2:
   version "6.6.2"
   resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.6.2.tgz#8096a7ac03f2cc4fe5860ef6e572810d9e01c0d2"
@@ -1488,6 +2047,11 @@ safe-buffer@^5.1.0:
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
   integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
 
+safe-buffer@~5.1.1:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
+  integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
+
 semver-compare@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/semver-compare/-/semver-compare-1.0.0.tgz#0dee216a1c941ab37e9efb1788f6afc5ff5537fc"
@@ -1497,6 +2061,16 @@ semver-regex@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/semver-regex/-/semver-regex-2.0.0.tgz#a93c2c5844539a770233379107b38c7b4ac9d338"
   integrity sha512-mUdIBBvdn0PLOeP3TEkMH7HHeUP3GjsXCwKarjv/kGmUFOYg1VqEemKhoQpWMu6X2I8kHeuVdGibLGkVK+/5Qw==
+
+semver@^5.4.1:
+  version "5.7.1"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
+  integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
+
+semver@^6.0.0, semver@^6.3.0:
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
+  integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
 
 semver@^7.2.1:
   version "7.3.2"
@@ -1532,6 +2106,24 @@ signal-exit@^3.0.2:
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.3.tgz#a1410c2edd8f077b08b4e253c8eacfcaf057461c"
   integrity sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==
 
+sinon-chai@^3.5.0:
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/sinon-chai/-/sinon-chai-3.5.0.tgz#c9a78304b0e15befe57ef68e8a85a00553f5c60e"
+  integrity sha512-IifbusYiQBpUxxFJkR3wTU68xzBN0+bxCScEaKMjBvAQERg6FnTTc1F17rseLb1tjmkJ23730AXpFI0c47FgAg==
+
+sinon@^9.2.1:
+  version "9.2.1"
+  resolved "https://registry.yarnpkg.com/sinon/-/sinon-9.2.1.tgz#64cc88beac718557055bd8caa526b34a2231be6d"
+  integrity sha512-naPfsamB5KEE1aiioaoqJ6MEhdUs/2vtI5w1hPAXX/UwvoPjXcwh1m5HiKx0HGgKR8lQSoFIgY5jM6KK8VrS9w==
+  dependencies:
+    "@sinonjs/commons" "^1.8.1"
+    "@sinonjs/fake-timers" "^6.0.1"
+    "@sinonjs/formatio" "^5.0.1"
+    "@sinonjs/samsam" "^5.2.0"
+    diff "^4.0.2"
+    nise "^4.0.4"
+    supports-color "^7.1.0"
+
 slash@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-3.0.0.tgz#6539be870c165adbd5240220dbe361f1bc4d4634"
@@ -1563,6 +2155,33 @@ slice-ansi@^4.0.0:
     ansi-styles "^4.0.0"
     astral-regex "^2.0.0"
     is-fullwidth-code-point "^3.0.0"
+
+snowflake-util@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/snowflake-util/-/snowflake-util-1.0.1.tgz#b7a24b9b6bbc124dde9384cfec9a6addd2960dc0"
+  integrity sha512-8R0BfbYMvkkXRKnW44OmHda4OQwwKgqhzQtSC03cIeyYN610yada3C76FSrksP3nAe1NPQSf1FmhxEAPFZu6cA==
+
+source-map@^0.5.0:
+  version "0.5.7"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
+  integrity sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=
+
+source-map@^0.6.1:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
+  integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
+
+spawn-wrap@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/spawn-wrap/-/spawn-wrap-2.0.0.tgz#103685b8b8f9b79771318827aa78650a610d457e"
+  integrity sha512-EeajNjfN9zMnULLwhZZQU3GWBoFNkbngTUPfaawT4RkMiviTxcX0qfhVbGey39mfctfDHkWtuecgQ8NJcyQWHg==
+  dependencies:
+    foreground-child "^2.0.0"
+    is-windows "^1.0.2"
+    make-dir "^3.0.0"
+    rimraf "^3.0.0"
+    signal-exit "^3.0.2"
+    which "^2.0.1"
 
 sprintf-js@~1.0.2:
   version "1.0.3"
@@ -1646,6 +2265,11 @@ strip-ansi@^6.0.0:
   dependencies:
     ansi-regex "^5.0.0"
 
+strip-bom@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-4.0.0.tgz#9c3505c1db45bcedca3d9cf7a16f5c5aa3901878"
+  integrity sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==
+
 strip-final-newline@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/strip-final-newline/-/strip-final-newline-2.0.0.tgz#89b852fb2fcbe936f6f4b3187afb0a12c1ab58ad"
@@ -1685,6 +2309,15 @@ table@^5.2.3:
     slice-ansi "^2.1.0"
     string-width "^3.0.0"
 
+test-exclude@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/test-exclude/-/test-exclude-6.0.0.tgz#04a8698661d805ea6fa293b6cb9e63ac044ef15e"
+  integrity sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==
+  dependencies:
+    "@istanbuljs/schema" "^0.1.2"
+    glob "^7.1.4"
+    minimatch "^3.0.4"
+
 text-table@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
@@ -1694,6 +2327,11 @@ through@^2.3.8:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
   integrity sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=
+
+to-fast-properties@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-2.0.0.tgz#dc5e698cbd079265bc73e0377681a4e4e83f616e"
+  integrity sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=
 
 to-regex-range@^5.0.1:
   version "5.0.1"
@@ -1719,7 +2357,7 @@ type-check@^0.4.0, type-check@~0.4.0:
   dependencies:
     prelude-ls "^1.2.1"
 
-type-detect@^4.0.0, type-detect@^4.0.5:
+type-detect@4.0.8, type-detect@^4.0.0, type-detect@^4.0.5, type-detect@^4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.8.tgz#7646fb5f18871cfbb7749e69bd39a6388eb7450c"
   integrity sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==
@@ -1729,10 +2367,17 @@ type-fest@^0.11.0:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.11.0.tgz#97abf0872310fed88a5c466b25681576145e33f1"
   integrity sha512-OdjXJxnCN1AvyLSzeKIgXTXxV+99ZuXl3Hpo9XpJAv9MBcHrrJOQ5kV7ypXOuQie+AmWG25hLbiKdwYTifzcfQ==
 
-type-fest@^0.8.1:
+type-fest@^0.8.0, type-fest@^0.8.1:
   version "0.8.1"
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.8.1.tgz#09e249ebde851d3b1e48d27c105444667f17b83d"
   integrity sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==
+
+typedarray-to-buffer@^3.1.5:
+  version "3.1.5"
+  resolved "https://registry.yarnpkg.com/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz#a97ee7a9ff42691b9f783ff1bc5112fe3fca9080"
+  integrity sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==
+  dependencies:
+    is-typedarray "^1.0.0"
 
 uri-js@^4.2.2:
   version "4.2.2"
@@ -1740,6 +2385,11 @@ uri-js@^4.2.2:
   integrity sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==
   dependencies:
     punycode "^2.1.0"
+
+uuid@^3.3.3:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
+  integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
 
 v8-compile-cache@^2.0.3:
   version "2.1.1"
@@ -1803,6 +2453,16 @@ wrappy@1:
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
   integrity sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=
 
+write-file-atomic@^3.0.0:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/write-file-atomic/-/write-file-atomic-3.0.3.tgz#56bd5c5a5c70481cd19c571bd39ab965a5de56e8"
+  integrity sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==
+  dependencies:
+    imurmurhash "^0.1.4"
+    is-typedarray "^1.0.0"
+    signal-exit "^3.0.2"
+    typedarray-to-buffer "^3.1.5"
+
 write@1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/write/-/write-1.0.3.tgz#0800e14523b923a387e415123c865616aae0f5c3"
@@ -1837,6 +2497,14 @@ yargs-parser@^15.0.1:
   version "15.0.1"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-15.0.1.tgz#54786af40b820dcb2fb8025b11b4d659d76323b3"
   integrity sha512-0OAMV2mAZQrs3FkNpDQcBk1x5HXb8X4twADss4S0Iuk+2dGnLOE/fRHrsYm542GduMveyA77OF4wrNJuanRCWw==
+  dependencies:
+    camelcase "^5.0.0"
+    decamelize "^1.2.0"
+
+yargs-parser@^18.1.2:
+  version "18.1.3"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-18.1.3.tgz#be68c4975c6b2abf469236b0c870362fab09a7b0"
+  integrity sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==
   dependencies:
     camelcase "^5.0.0"
     decamelize "^1.2.0"
@@ -1884,3 +2552,20 @@ yargs@^14.2.3:
     which-module "^2.0.0"
     y18n "^4.0.0"
     yargs-parser "^15.0.1"
+
+yargs@^15.0.2:
+  version "15.4.1"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-15.4.1.tgz#0d87a16de01aee9d8bec2bfbf74f67851730f4f8"
+  integrity sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==
+  dependencies:
+    cliui "^6.0.0"
+    decamelize "^1.2.0"
+    find-up "^4.1.0"
+    get-caller-file "^2.0.1"
+    require-directory "^2.1.1"
+    require-main-filename "^2.0.0"
+    set-blocking "^2.0.0"
+    string-width "^4.2.0"
+    which-module "^2.0.0"
+    y18n "^4.0.0"
+    yargs-parser "^18.1.2"


### PR DESCRIPTION
This adds a command, `!vc`, that allows all users to create temporary voice channels, marked with ⚡. Users can delete these channels manually if they want, and there is a command to delete everything made by the plugin. Additionally, channels that go unoccupied for some time (about 10 minutes) will be automatically cleaned up.

This PR still needs tests, but should be good to go besides that.